### PR TITLE
Investigate rss-reader content loading issue

### DIFF
--- a/projects/rss-reader/backend/Dockerfile
+++ b/projects/rss-reader/backend/Dockerfile
@@ -34,9 +34,9 @@ USER appuser
 # Expose port
 EXPOSE 5001
 
-# Health check
+# Health check (respect dynamic $PORT in Railway; default to 5001 locally)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:5001/api/stats || exit 1
+    CMD sh -c 'curl -f http://localhost:${PORT:-5001}/api/stats || exit 1'
 
 # Run the application with Gunicorn for production
 CMD ["gunicorn", "--bind", "0.0.0.0:5001", "--workers", "1", "--threads", "2", "--timeout", "30", "--max-requests", "100", "--max-requests-jitter", "10", "wsgi:app"] 


### PR DESCRIPTION
Update Dockerfile healthcheck to respect dynamic PORT environment variable for platforms like Railway.

---
<a href="https://cursor.com/background-agent?bcId=bc-c18817c8-d126-4f28-a276-e4aef7c62942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c18817c8-d126-4f28-a276-e4aef7c62942">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

